### PR TITLE
docs: improve readme clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plasma Wayland Protocols
 
-This project should be installing only the xml files of the non-standard wayland
+This project installs the xml files of the non-standard wayland
 protocols we use in Plasma.
 
 They are installed to $PREFIX/share/plasma-wayland-protocols.


### PR DESCRIPTION
The first line of the README is not easily parseable, without reading it over a few times. This PR aims to fix that.